### PR TITLE
docs: encode Phase 60 workflow lessons into sprint/review workflows

### DIFF
--- a/.claude/workflows/agent-teams.md
+++ b/.claude/workflows/agent-teams.md
@@ -130,7 +130,7 @@ would have caught it before Task 3 replicated the pattern.
 
 Also available via MCP: `team_recipe(recipe: "incremental-review", context: "...", files: "...")`
 
-## Lessons Learned (Feb 9, 2026)
+## Lessons Learned (Feb 11, 2026 — updated)
 
 1. **Task list context switches** — When you create a team, task operations target
    the team's task list. After `TeamDelete`, context returns to the main list.
@@ -155,6 +155,15 @@ Also available via MCP: `team_recipe(recipe: "incremental-review", context: "...
 
 7. **Reviews work best, implementation needs more testing** — Parallel review is
    the proven use case. Parallel implementation carries risk of file conflicts.
+
+8. **Use teams for sprint tasks when 3+ are independent** — In Phase 60, 4 of 6
+   tasks had no dependencies. Serializing them added ~15 min of wall time that
+   parallelization would have eliminated. When a plan identifies independent tasks,
+   that's the signal to spawn teammates.
+
+9. **Always run BOTH code + security reviewers** — In Phase 60, only running
+   code-reviewer missed that the tier check could receive legacy enum values.
+   Security-reviewer catches auth/boundary issues that code-reviewer doesn't focus on.
 
 ## Display Mode
 

--- a/.claude/workflows/session-workflow.md
+++ b/.claude/workflows/session-workflow.md
@@ -6,10 +6,11 @@ Standard workflow for every Claude Code session working on Radl.
 
 1. **Check sprint state**: Use `mcp__radl-ops__sprint_status` MCP tool
 2. **Check service health**: Use `mcp__radl-ops__health_check` if available
-3. **Parallel context loading**: Read these files simultaneously (parallel Read calls):
+3. **Parallel context loading**: Read ALL needed files in a single batch of parallel Read calls:
    - `/home/hb/radl/.planning/STATE.md` for current progress
-   - Key source files relevant to planned work
+   - ALL source files you plan to modify (read them together, not one-at-a-time)
    - Any test files for areas being modified
+   - For 10+ files, batch into 2-3 parallel Read calls (5 files each)
 4. **Create feature branch** if starting new work (never work on main)
 
 ## During Session
@@ -46,11 +47,23 @@ After completing a task that introduces a **new pattern**:
 - At ~75% context: Use `/strategic-compact` skill
 - Before compaction: Save sprint state via `sprint.sh checkpoint`
 
+### Data Flow Verification (CRITICAL for UI changes)
+When adding new data to a list page or card component, always trace the full path:
+1. **Prisma query** — Does it include the new relations/fields?
+2. **Server page** — Does the props mapping pass the new fields to the client?
+3. **Client component** — Does it accept and forward the fields to child components?
+4. **Render** — Does the child component actually display them?
+
+If any layer explicitly maps props (e.g., `.map(e => ({ id: e.id, ... }))`), new
+fields will be **silently dropped** unless added to the mapping. This was a real bug
+in Phase 60: API + client updated, but server page mapping dropped maintenance fields.
+
 ### Code Quality Gates
 After writing or modifying code:
 1. `npm run typecheck` — must pass
-2. Use **code-reviewer** agent for non-trivial changes
-3. Use **security-reviewer** agent for auth/API/input handling changes
+2. Use **code-reviewer** AND **security-reviewer** agents for non-trivial changes
+   (launch both in parallel with `run_in_background: true`)
+3. Never skip security-reviewer for auth, tier enforcement, or API boundary changes
 
 ## Session End
 


### PR DESCRIPTION
- Add task parallelization guidance (use teams when 3+ tasks are independent)
- Add data flow verification rule (trace server page → prisma → props → render)
- Mandate BOTH code-reviewer + security-reviewer before PRs
- Require per-task commits instead of monolith sprint commits
- Emphasize parallel file reads at session start (batch, not sequential)
- Add lessons 8-9 to agent-teams (team for independent tasks, dual review)