### PR TITLE
fix(watcher): prevent CLAUDE.md drift + document auto-merge cron

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,15 @@ scripts/setup-labels.sh     # Create GitHub labels
 - 75 max turns per issue (`WATCHER_MAX_TURNS`)
 - `auto/issue-<num>-<slug>` branch naming
 - Skips issues with `failed`, `decomposed`, or `in-progress` labels
+- Cancel mid-execution by adding `cancel` label to the issue
+- Watcher instances MUST NOT modify CLAUDE.md or .github/workflows/
 - Logs: `logs/watcher/<date>-issue-<num>.log`
+
+**Auto-merge (Radl repo):**
+PRs created by the watcher are auto-merged by `.github/workflows/auto-merge.yml`:
+- Cron runs every 5 minutes to catch PRs (+ event-driven `check_suite` and label triggers)
+- Requires `watcher` label, no `hold` label, all checks passing, 15-min safety delay
+- On merge: linked issues auto-closed, labels updated, comment posted
 
 **Auto-decompose for broad issues:**
 When a large/vague issue is approved (e.g., "audit all UI/UX"), Claude automatically:

--- a/scripts/watcher-prompt.md
+++ b/scripts/watcher-prompt.md
@@ -71,6 +71,8 @@ You MUST NOT:
 - Delete production data
 - Commit secrets
 - Modify CI/CD pipelines
+- Modify CLAUDE.md (if you discover patterns worth documenting, add them as a comment on issue #{{ISSUE_NUM}} instead)
+- Modify .github/workflows/ files
 - Exceed the scope described in this issue
 
 ## Error Recovery


### PR DESCRIPTION
## Summary

- Watcher prompt now explicitly prevents claude -p instances from modifying CLAUDE.md and .github/workflows/ files
- CLAUDE.md documents the auto-merge cron fallback and cancel mechanism

## Companion PR

Radl PR #56 (merged) adds schedule cron to auto-merge.yml, fixing the timing race that left PRs #50-54 stuck.

## Test plan

- [ ] Watcher instance does NOT modify CLAUDE.md
- [ ] Auto-merge cron catches new PRs within 5-10 minutes